### PR TITLE
Fix button styles to avoid missing Material3 resources

### DIFF
--- a/app/src/main/res/layout/fragment_dashboard.xml
+++ b/app/src/main/res/layout/fragment_dashboard.xml
@@ -106,14 +106,14 @@
 
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/startTimerButton"
-                        style="@style/Widget.Material3.Button.Filled"
+                        style="?attr/materialButtonStyle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/dashboard_start" />
 
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/resetTimerButton"
-                        style="@style/Widget.Material3.Button.Outlined"
+                        style="?attr/materialButtonOutlinedStyle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="12dp"

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -84,7 +84,7 @@
 
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/changeReminderButton"
-                        style="@style/Widget.Material3.Button.TextButton"
+                        style="?attr/materialTextButtonStyle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/settings_change_time" />
@@ -121,7 +121,7 @@
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/updateDisplayNameButton"
-                    style="@style/Widget.Material3.Button.Filled"
+                    style="?attr/materialButtonStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="12dp"
@@ -129,7 +129,7 @@
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/signOutButton"
-                    style="@style/Widget.Material3.Button.Outlined"
+                    style="?attr/materialButtonOutlinedStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="12dp"


### PR DESCRIPTION
## Summary
- replace Material3 button style references in dashboard and settings layouts with theme attribute styles to ensure compatibility

## Testing
- `./gradlew :app:assembleDebug` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68e50946bf90832d970910d90a3d4a3a